### PR TITLE
Pin third-party actions to currently used SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Elixir and Erlang
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}


### PR DESCRIPTION
In light of the [recent compromise of the tj-actions/changed-files action](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), we’re trying to reduce the risk incurred from our use of third-party actions. 

[GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning third-party actions to a full length commit SHA as a good security practice, and as the only way to use an action as an immutable release.

This PR pins this repository’s third-party actions to their currently used version’s commit SHA, as indicated in the logs for the most recent workflow runs, or from the most recent matching release if logs are not available.

If desired, we can also look into adding a Dependabot configuration to help keep actions updated by automatically creating update PRs when new versions are available.
